### PR TITLE
ppd-filter.c: Generate media-col if media-col-default exists

### DIFF
--- a/ppd/ppd-filter.c
+++ b/ppd/ppd-filter.c
@@ -739,9 +739,8 @@ ppdFilterLoadPPD(cf_filter_data_t *data) // I/O - Job and printer data
 
   page_size = cupsGetOption("PageSize", data->num_options, data->options);
   media = cupsGetOption("media", data->num_options, data->options);
-  if ((page_size || media) &&
-      (attr = ippFindAttribute(data->printer_attrs, "media-col-default",
-			       IPP_TAG_ZERO)) != NULL)
+  if ((attr = ippFindAttribute(data->printer_attrs, "media-col-default",
+			IPP_TAG_ZERO)) != NULL)
   {
     // We have already applied the settings of these options to the
     // PPD file and converted the PPD option settings into the printer


### PR DESCRIPTION
We would generate `media-col` attribute only if we had `media-col-default` attribute and `PageSize` or `media` options, which doesn't seem to be always the case for `PageSize` and `media`. These options usually are not default options and if the application doesn't send them, they are not sent to filters.

The current implementation breaks image printing for (at least) printers installed with Postscript driver - the printer outputs an empty sheet of paper. It happens because `cfFilterImageToPDF()` doesn't get page size by other means.