### PR TITLE
ppd/ppd-ipp.c: Use make when constructing printer-make-model attr

### DIFF
--- a/ppd/ppd-ipp.c
+++ b/ppd/ppd-ipp.c
@@ -1381,8 +1381,11 @@ ppdLoadAttributes(
   }
 
   // printer-make-andXS-model
+  char	make_model[128];		// Manufacturer and Model value
+
+  snprintf(make_model, sizeof(make_model), "%s %s", ppd->manufacturer, ppd->nickname);
   ippAddString(attrs, IPP_TAG_PRINTER, IPP_TAG_TEXT, "printer-make-and-model",
-	       NULL, ppd->nickname);
+	       NULL, make_model);
 
   // printer-resolution-default
   ippAddResolution(attrs, IPP_TAG_PRINTER, "printer-resolution-default",


### PR DESCRIPTION
We used only PPD Nickname which does not contain manufacturer in some drivers (like Utax) when constructing printer-make-and-model IPP attribute, and then used the attribute when matching with strings representing manufacturers in filter functions.

This caused internal hacks for specific printer manufacturers weren't applied, causing breakage during printing.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2192912 .