### PR TITLE
raster-interpreter.c: Fix crash when incoming `*ptr` is NULL

### DIFF
--- a/ppd/raster-interpret.c
+++ b/ppd/raster-interpret.c
@@ -1203,6 +1203,9 @@ ppd_scan_ps(_ppd_ps_stack_t  *st,	// I  - Stack
   int			parens;		// Parenthesis nesting level
 
 
+  if (!*ptr)
+    return (NULL);
+
   //
   // Skip leading whitespace...
   //


### PR DESCRIPTION
The same fix as in OpenPrinting/CUPS#831