### PR TITLE
ppd-generator.c: Check for `urf-supported` if we found `image/urf`

### DIFF
--- a/ppd/ppd-generator.c
+++ b/ppd/ppd-generator.c
@@ -723,7 +723,8 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
     is_pdf = 1;
   }
 #ifdef CUPS_RASTER_HAVE_APPLERASTER
-  else if (cupsArrayFind(pdl_list, "image/urf"))
+  else if (cupsArrayFind(pdl_list, "image/urf") &&
+	   (ippFindAttribute(supported, "urf-supported", IPP_TAG_KEYWORD) != NULL))
   {
     int resStore = 0; // Variable for storing the no. of resolutions in the resolution array 
     int resArray[__INT16_MAX__]; // Creating a resolution array supporting a maximum of 32767 resolutions.


### PR DESCRIPTION
Some devices has AirPrint disabled by default/admins has disabled it, but the device reports `image/urf` in `document-format-supported`, but provides no `urf-supported` attribute, which breaks PPD generation.

We should check for `urf-supported` once we found `image/urf`, so in case the device is missing `urf-supported` and provides other driverless standard, the other standard is used for PPD generation.

Fixes [Fedora issue](https://bugzilla.redhat.com/show_bug.cgi?id=2263053)