### PR TITLE
build: use pkg-config to find zlib

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -120,10 +120,12 @@ libppd_la_SOURCES = \
 	$(pkgppddefs_DATA)
 libppd_la_LIBADD = \
 	$(LIBCUPSFILTERS_LIBS) \
-	$(CUPS_LIBS)
+	$(CUPS_LIBS) \
+	$(ZLIB_LIBS)
 libppd_la_CFLAGS = \
 	$(LIBCUPSFILTERS_CFLAGS) \
-	$(CUPS_CFLAGS)
+	$(CUPS_CFLAGS) \
+	$(ZLIB_CFLAGS)
 libppd_la_CXXFLAGS = \
 	$(libppd_la_CFLAGS)
 libppd_la_LDFLAGS = \

--- a/configure.ac
+++ b/configure.ac
@@ -164,6 +164,11 @@ AC_SUBST(CUPS_STATEDIR)
 # ========================
 PKG_CHECK_MODULES([LIBCUPSFILTERS], [libcupsfilters])
 
+# ==============
+# Check for zlib
+# ==============
+PKG_CHECK_MODULES([ZLIB], [zlib])
+
 # ============================================================
 # Check for whether we want to install the testppdfile utility
 # ============================================================
@@ -220,7 +225,6 @@ AC_CHECK_HEADERS([stdlib.h])
 AC_CHECK_HEADERS([sys/stat.h])
 AC_CHECK_HEADERS([sys/types.h])
 AC_CHECK_HEADERS([unistd.h])
-AC_CHECK_HEADERS([zlib.h])
 AC_CHECK_HEADERS([endian.h])
 AC_CHECK_HEADERS([dirent.h])
 AC_CHECK_HEADERS([sys/ioctl.h])


### PR DESCRIPTION
When building with slibtool it fails with undefined references for `-lz` because the build sets `-no-undefined` in the `LDFLAGS`. This doesn't fail with GNU libtool because they silently ignore `-no-undefined`.

To solve this the build now uses `PKG_CHECK_MODULES` to find zlib.

Gentoo issue: https://bugs.gentoo.org/920273