### PR TITLE
ppd-cache.c: Use 0.5mm for delta when comparing sizes

### DIFF
--- a/ppd/ppd-cache.c
+++ b/ppd/ppd-cache.c
@@ -26,7 +26,7 @@
 // Macro to test for two almost-equal PWG measurements.
 //
 
-#define _PPD_PWG_EQUIVALENT(x, y)	(abs((x)-(y)) < 2)
+#define _PPD_PWG_EQUIVALENT(x, y)	(abs((x)-(y)) < 50)
 
 //
 // Macros to work around typos in older libcups version


### PR DESCRIPTION
@szlt5 found out libppd does not use the same delta as CUPS, which causes filters to use first size from the array, because the similar size according PWG (which recommends max delta 0.5mm) is not matched as useable.

Related to #29, but not fixing the original issue.

@szlt5 thank you for finding it!