### PR TITLE
pdftops: Use Poppler for a few old Epson laser printers

### DIFF
--- a/ppd/pdftops.c
+++ b/ppd/pdftops.c
@@ -546,6 +546,28 @@ ppdFilterPDFToPS(int inputfd,		// I - File descriptor input stream
 	break;
       }
     }
+
+    //
+    // Use Poppler instead of Ghostscript for old Epson laser printers based
+    // on epsonepl(ijs) as the page ends up off-centre by about 6~7mm towards
+    // the top right of the page.
+    //
+    if (make_model[0] &&
+     !strncasecmp(make_model, "Epson", 5) &&
+     (ptr = strcasestr(make_model, "EPL-")) &&
+      (!strncasecmp(ptr + 4, "5700L", 5) ||
+       !strncasecmp(ptr + 4, "5800L", 5) ||
+       !strncasecmp(ptr + 4, "5900L", 5) ||
+       !strncasecmp(ptr + 4, "6100L", 5) ||
+       !strncasecmp(ptr + 4, "6200L", 5)))
+    {
+	    if (log) log(ld, CF_LOGLEVEL_DEBUG,
+			 "ppdFilterPDFToPS: Switching to Poppler's pdftops instead of "
+			 "Ghostscript for old epsoneplijs (EPL-5700L, EPL-5800L, "
+			 "EPL-5900L, EPL-6100L, EPL-6200L) printers to work around "
+			 "off-centre printing");
+	    renderer = PDFTOPS;
+    }
   }
 
   //


### PR DESCRIPTION
This works around documents being printed off-centre, shifted towards the top right, on Epson laser printers using [epsoneplijs](https://github.com/lorf/epsoneplijs) (EPL-5700L, EPL-5800L, EPL-5900L, EPL-6100L, EPL-6200L). Tested specifically with an EPL-6200L.

The issue can be visualised easily with a printout of the PDF found at https://moral.net.au/writing/2023/05/19/printer_actual_size/ (slightly modified to add an additional box right around the printable area).

With Ghostscript (default) the top right is cut off and the margins are visible on the bottom and left sides: 
<img src="https://github.com/user-attachments/assets/3bf705ac-edd6-45cc-8c0b-6afe91a2616a" width=60% height=60%>


With Poppler's pdftops the margins are not visible and nothing is cut off:
<img src="https://github.com/user-attachments/assets/f69dd244-1dff-462c-9da9-88976db4113e" width=60% height=60%>

The solution was discovered by "bisecting" between old Ubuntu versions. It was identified that for Ubuntu 12.10 and onwards the packagers stopped setting Poppler's pdftops as the default renderer during compile time, thus revealing this issue.