### PR TITLE
raster-interpret.c: Verify base for `strtol()`

### DIFF
--- a/ppd/raster-interpret.c
+++ b/ppd/raster-interpret.c
@@ -1200,7 +1200,8 @@ ppd_scan_ps(_ppd_ps_stack_t  *st,	// I  - Stack
 			*cur,		// Current position
 			*valptr,	// Pointer into value string
 			*valend;	// End of value string
-  int			parens;		// Parenthesis nesting level
+  int			parens,		/* Parenthesis nesting level */
+			base;		/* Numeric base for strtol() */
 
 
   if (!*ptr)
@@ -1454,13 +1455,22 @@ ppd_scan_ps(_ppd_ps_stack_t  *st,	// I  - Stack
 	  if (!isdigit(*cur & 255))
 	    break;
 
-        if (*cur == '#')
+	if (*cur == '#')
 	{
 	  //
 	  // Integer with radix...
 	  //
 
-          obj.value.number = strtol(cur + 1, &cur, atoi(start));
+	  base = atoi(start);
+
+	 /*
+	  * Postscript language reference manual dictates numbers from 2 to 36 as base...
+	  */
+
+	  if (base < 2 || base > 36)
+	    return (NULL);
+
+	  obj.value.number = strtol(cur + 1, &cur, base);
 	  break;
 	}
 	else if (strchr(".Ee()<>[]{}/%", *cur) || isspace(*cur & 255))


### PR DESCRIPTION
Input for atoi() can be bad number for argument base in strtol(), causing returning an incorrect pointer address and later segfault.

Break out from function if the base is incorrect.