### PR TITLE
Check that ppd->nickname is not NULL

### DIFF
--- a/ppd/ppd-cache.c
+++ b/ppd/ppd-cache.c
@@ -2475,7 +2475,8 @@ ppdCacheAssignPresets(ppd_file_t *ppd,
       // control at the composite option
       //
 
-      if (strstr(ppd->nickname, "Foomatic") &&
+      if (ppd->nickname &&
+          strstr(ppd->nickname, "Foomatic") &&
 	  !strncmp(option->choices[0].choice, "From", 4) &&
 	  ppdFindOption(ppd, option->choices[0].choice + 4))
       {


### PR DESCRIPTION
This fixes the crash if the PPD file has `OpenUI` group not in the [reserved list of words](https://github.com/OpenPrinting/libppd/blob/0851d121a38a5d935ce41b3d10e24fe8b1e18968/ppd/ppd-cache.c#L2446-L2458) which trigger `ppd->nickname`  null pointer dereferencing if there's no nickname in the PPD.

https://github.com/OpenPrinting/libppd/blob/0851d121a38a5d935ce41b3d10e24fe8b1e18968/ppd/ppd-cache.c#L2478

