### PR TITLE
Introducing ppdCacheGetSize2()

### DIFF
--- a/ppd/ppd-ipp.c
+++ b/ppd/ppd-ipp.c
@@ -1,6 +1,7 @@
 //
 // PPD options <-> IPP attributes routines for libppd.
 //
+// Copyright © 2022-2025 by OpenPrinting
 // Copyright © 2007-2019 by Apple Inc.
 // Copyright © 1997-2007 by Easy Software Products, all rights reserved.
 //
@@ -432,14 +433,7 @@ ppdLoadAttributes(
     // Look up default size...
     //
 
-    for (i = 0, pwg_size = pc->sizes; i < pc->num_sizes; i ++, pwg_size ++)
-    {
-      if (!strcmp(pwg_size->map.ppd, ppd_size->name))
-      {
-        default_size = pwg_size;
-        break;
-      }
-    }
+    default_size = ppdCacheGetSize2(pc, ppd_size->name, ppd_size);
 
     //
     // Try to find one with the same size...

--- a/ppd/ppd.h
+++ b/ppd/ppd.h
@@ -776,6 +776,9 @@ extern const char	*ppdCacheGetPageSize(ppd_cache_t *pc, ipp_t *job,
 					     const char *keyword, int *exact);
 extern pwg_size_t	*ppdCacheGetSize(ppd_cache_t *pc,
 					 const char *page_size);
+extern pwg_size_t	*ppdCacheGetSize2(ppd_cache_t *pc,
+					 const char *page_size,
+					 ppd_size_t *ppd_size);
 extern const char	*ppdCacheGetSource(ppd_cache_t *pc,
 					   const char *input_slot);
 extern const char	*ppdCacheGetType(ppd_cache_t *pc,


### PR DESCRIPTION
Adopting the fix for CUPS issue #1238 for getting custom size names.

The PR introduces the function to prevent API breakage - if you would like to break API and bump soname number instead, do let me know.