### PR TITLE
use our own copy of ppdClose()

### DIFF
--- a/ppd/ppd.c
+++ b/ppd/ppd.c
@@ -106,11 +106,11 @@ static int		ppd_update_filters(ppd_file_t *ppd,
 
 
 //
-// 'ppdClose()' - Free all memory used by the PPD file.
+// 'ppdClose2()' - Free all memory used by the PPD file.
 //
 
 void
-ppdClose(ppd_file_t *ppd)		// I - PPD file record
+ppdClose2(ppd_file_t *ppd)		// I - PPD file record
 {
   int			i;		// Looping var
   ppd_group_t		*group;		// Current group

--- a/ppd/ppd.h
+++ b/ppd/ppd.h
@@ -611,7 +611,9 @@ typedef struct
 // Definition for backward compatibility, will be removed soon
 #define cupsMarkOptions cupsMarkOptions_USE_ppdMarkOptions_INSTEAD
 
-extern void		ppdClose(ppd_file_t *ppd);
+extern void		ppdClose2(ppd_file_t *ppd);
+#define ppdClose ppdClose2
+
 extern int		ppdCollect(ppd_file_t *ppd, ppd_section_t section,
 			           ppd_choice_t  ***choices);
 extern int		ppdConflicts(ppd_file_t *ppd);


### PR DESCRIPTION
to avoid double-frees and memory corruption on OpenBSD at least, do not rely on cups' internal _ppdCacheDestroy() that has a slightly different structure

fixes #62