### PR TITLE
Add GitHub Actions workflow for libppd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Build libppd
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            autoconf \
+            automake \
+            autopoint \
+            gettext \
+            libtool \
+            pkg-config \
+            libcups2-dev \
+            libcupsfilters-dev \
+            ghostscript \
+            poppler-utils \
+            mupdf-tools 
+
+      - name: Build project
+        run: |
+          ./autogen.sh
+          ./configure
+          make
+      
+      - name: Run tests
+        run: make check


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automatically build libppd on every push and pull request.

The workflow installs the required dependencies and runs the build and tests (./autogen.sh, ./configure, make, make check).

Actions runs:

https://github.com/n0y0nD/libppd/actions/runs/23081781911