### PR TITLE
Fix stack-buffer-overflow in ppdCacheCreateWithPPD()

### DIFF
--- a/ppd/ppd-cache.c
+++ b/ppd/ppd-cache.c
@@ -1444,10 +1444,14 @@ ppdCacheCreateWithPPD(ppd_file_t *ppd)	// I - PPD file
     // Generate custom size data...
     //
 
-    pwgFormatSizeName(pwg_keyword, sizeof(pwg_keyword), "custom", "max",
-		      PWG_FROM_POINTS(ppd->custom_max[0]),
-		      PWG_FROM_POINTS(ppd->custom_max[1]), NULL);
-
+  if (!pwgFormatSizeName(pwg_keyword, sizeof(pwg_keyword),"custom", "max",
+                          PWG_FROM_POINTS(ppd->custom_max[0]),
+                          PWG_FROM_POINTS(ppd->custom_max[1]), NULL))
+      {
+        DEBUG_puts("ppdCacheCreateWithPPD: pwgFormatSizeName failure.");
+        goto create_error;
+      }
+      
     // Some PPD files have upper limits too large to be treated with
     // int numbers, if we have an overflow (negative result for one
     // dimension) use a fixed, large value instead

--- a/ppd/sbo_test.ppd
+++ b/ppd/sbo_test.ppd
@@ -37,7 +37,6 @@
 
 *% These constraints are used to test ppdConflicts() and cupsResolveConflicts()
 *cupsUIConstraints envelope: "*PageSize Letter *InputSlot Envelope"
-*cupsUIConstraints envelope: "*PageSizeß¾ËßÕ¶‘Š‹¬“‹ßº‘‰š“šİõÕœŠŒª¶­šŒ“‰šßš‘‰š“šÅßİÕ¶‘Š‹¬“‹ß²anual *PageSize Env10"
 
 *cupsUIConstraints envphoto: "*PageSize Env10 *InputSlot Envelope *Quality Photo"
 *cupsUIResolver envphoto: "*Quality Normal"
@@ -97,7 +96,7 @@
 *PaperDimension A4:	"595 842"
 *PaperDimension Env10:	"297 684"
 
-*% Custom page size support
+*% This custom page size is used to test ppdCacheCreateWithPPD() with out-of-range dimension
 *HWMargins:      0 0 0 0
 *NonUIOrderDependency: 100 AnySetup *CustomPageSize True
 *CustomPageSize True/Custom Page Size: "PageSize=Custom"

--- a/ppd/sbo_test.ppd
+++ b/ppd/sbo_test.ppd
@@ -1,0 +1,243 @@
+*PPD-Adobe: "4.3"
+*%
+*% Test PPD file #2 for CUPS.
+*%
+*% This file is used to test the CUPS PPD API functions and cannot be
+*% used with any known printers.  Look on the CUPS web site for working PPD
+*% files.
+*%
+*% If you are a PPD file developer, consider using the PPD compiler (ppdc)
+*% to create your PPD files - not only will it save you time, it produces
+*% consistently high-quality files.
+*%
+*% Copyright (c) 2007-2018 by Apple Inc.
+*% Copyright (c) 2002-2006 by Easy Software Products.
+*%
+*% Licensed under Apache License v2.0.  See the file "LICENSE" for more
+*% information.
+*FormatVersion:	"4.3"
+*FileVersion:	"2.3"
+*LanguageVersion: English
+*LanguageEncoding: ISOLatin1
+*PCFileName:	"TEST.PPD"
+*Manufacturer:	"Apple"
+*Product:	"(Test2)"
+*cupsVersion:	2.3
+*ModelName:     "Test2"
+*ShortNickName: "Test2"
+*NickName:      "Test2 for CUPS"
+*PSVersion:	"(3010.000) 0"
+*LanguageLevel:	"3"
+*ColorDevice:	True
+*DefaultColorSpace: RGB
+*FileSystem:	False
+*Throughput:	"1"
+*LandscapeOrientation: Plus90
+*TTRasterizer:	Type42
+
+*% These constraints are used to test ppdConflicts() and cupsResolveConflicts()
+*cupsUIConstraints envelope: "*PageSize Letter *InputSlot Envelope"
+*cupsUIConstraints envelope: "*PageSizeﬂæÀﬂ’∂ëèäã¨ìêãﬂ∫ëâöìêèö›ı’úäèå™∂≠öåêìâöçﬂöëâöìêèö≈ﬂ›’∂ëèäã¨ìêãﬂ≤anual *PageSize Env10"
+
+*cupsUIConstraints envphoto: "*PageSize Env10 *InputSlot Envelope *Quality Photo"
+*cupsUIResolver envphoto: "*Quality Normal"
+
+*% This constraint is used to test ppdInstallableConflict()
+*cupsUIConstraints: "*Duplex *InstalledDuplexer False"
+
+*% These constraints are used to test the loop detection code in cupsResolveConflicts()
+*cupsUIConstraints loop1: "*PageSize A4 *Quality Photo"
+*cupsUIResolver loop1: "*Quality Normal"
+*cupsUIConstraints loop2: "*PageSize A4 *Quality Normal"
+*cupsUIResolver loop2: "*Quality Photo"
+
+*% For PageSize, we have put all of the translations in-line...
+*OpenUI *PageSize/Page Size: PickOne
+*fr.Translation PageSize/French Page Size: ""
+*fr_CA.Translation PageSize/French Canadian Page Size: ""
+*OrderDependency: 10 AnySetup *PageSize
+*DefaultPageSize: Letter
+*PageSize Letter/US Letter:	"PageSize=Letter"
+*fr.PageSize Letter/French US Letter: ""
+*fr_CA.PageSize Letter/French Canadian US Letter: ""
+*PageSize A4/A4:		"PageSize=A4"
+*fr.PageSize A4/French A4: ""
+*fr_CA.PageSize A4/French Canadian A4: ""
+*PageSize Env10/#10 Envelope:	"PageSize=Env10"
+*fr.PageSize Env10/French #10 Envelope: ""
+*fr_CA.PageSize Env10/French Canadian #10 Envelope: ""
+*CloseUI: *PageSize
+
+*% For PageRegion, we have separated the translations...
+*OpenUI *PageRegion/Page Region: PickOne
+*OrderDependency: 10 AnySetup *PageRegion
+*DefaultPageRegion: Letter
+*PageRegion Letter/US Letter:	"PageRegion=Letter"
+*PageRegion A4/A4:		"PageRegion=A4"
+*PageRegion Env10/#10 Envelope:	"PageRegion=Env10"
+*CloseUI: *PageRegion
+
+*fr.Translation PageRegion/French Page Region: ""
+*fr.PageRegion Letter/French US Letter: ""
+*fr.PageRegion A4/French A4: ""
+*fr.PageRegion Env10/French #10 Envelope: ""
+
+*fr_CA.Translation PageRegion/French Canadian Page Region: ""
+*fr_CA.PageRegion Letter/French Canadian US Letter: ""
+*fr_CA.PageRegion A4/French Canadian A4: ""
+*fr_CA.PageRegion Env10/French Canadian #10 Envelope: ""
+
+*DefaultImageableArea: Letter
+*ImageableArea Letter:	"18 36 594 756"
+*ImageableArea A4:	"18 36 577 806"
+*ImageableArea Env10:	"18 36 279 648"
+
+*DefaultPaperDimension: Letter
+*PaperDimension Letter:	"612 792"
+*PaperDimension A4:	"595 842"
+*PaperDimension Env10:	"297 684"
+
+*% Custom page size support
+*HWMargins:      0 0 0 0
+*NonUIOrderDependency: 100 AnySetup *CustomPageSize True
+*CustomPageSize True/Custom Page Size: "PageSize=Custom"
+*ParamCustomPageSize Width:        1 points 36 1E80
+*ParamCustomPageSize Height:       2 points 36 86400
+*ParamCustomPageSize WidthOffset/Width Offset:  3 points 0 0
+*ParamCustomPageSize HeightOffset/Height Offset: 4 points 0 0
+*ParamCustomPageSize Orientation:  5 int 0 0
+
+*cupsMediaQualifier2: InputSlot
+*cupsMediaQualifier3: Quality
+*cupsMaxSize .Manual.: "1000 1000"
+*cupsMinSize .Manual.: "100 100"
+*cupsMinSize .Manual.Photo: "200 200"
+*cupsMinSize ..Photo: "300 300"
+
+*OpenUI *InputSlot/Input Slot: PickOne
+*OrderDependency: 20 AnySetup *InputSlot
+*DefaultInputSlot: Tray
+*InputSlot Tray/Tray: "InputSlot=Tray"
+*InputSlot Manual/Manual Feed: "InputSlot=Manual"
+*InputSlot Envelope/Envelope Feed: "InputSlot=Envelope"
+*CloseUI: *InputSlot
+
+*OpenUI *Quality/Output Mode: PickOne
+*OrderDependency: 20 AnySetup *Quality
+*DefaultQuality: Normal
+*Quality Draft: "Quality=Draft"
+*Quality Normal: "Quality=Normal"
+*Quality Photo: "Quality=Photo"
+*CloseUI: *Quality
+
+*OpenUI *Duplex/2-Sided Printing: PickOne
+*OrderDependency: 10 DocumentSetup *Duplex
+*DefaultDuplex: None
+*Duplex None/Off: "Duplex=None"
+*Duplex DuplexNoTumble/Long Edge: "Duplex=DuplexNoTumble"
+*Duplex DuplexTumble/Short Edge: "Duplex=DuplexTumble"
+*CloseUI: *Duplex
+
+*% Installable option...
+*OpenGroup: InstallableOptions/Installable Options
+*OpenUI InstalledDuplexer/Duplexer Installed: Boolean
+*DefaultInstalledDuplexer: False
+*InstalledDuplexer False: ""
+*InstalledDuplexer True: ""
+*CloseUI: *InstalledDuplexer
+*CloseGroup: InstallableOptions
+
+*% Custom options...
+*OpenGroup: Extended/Extended Options
+
+*OpenUI IntOption/Integer: PickOne
+*OrderDependency: 30 AnySetup *IntOption
+*DefaultIntOption: None
+*IntOption None: ""
+*IntOption 1: "IntOption=1"
+*IntOption 2: "IntOption=2"
+*IntOption 3: "IntOption=3"
+*CloseUI: *IntOption
+
+*CustomIntOption True/Custom Integer: "IntOption=Custom"
+*ParamCustomIntOption Integer: 1 int -100 100
+
+*OpenUI StringOption/String: PickOne
+*OrderDependency: 40 AnySetup *StringOption
+*DefaultStringOption: None
+*StringOption None: ""
+*StringOption foo: "StringOption=foo"
+*StringOption bar: "StringOption=bar"
+*CloseUI: *StringOption
+
+*CustomStringOption True/Custom String: "StringOption=Custom"
+*ParamCustomStringOption String: 1 string 1 10
+
+*CloseGroup: Extended
+
+*% IPP reasons for ppdLocalizeIPPReason tests
+*cupsIPPReason foo/Foo Reason: "http://foo/bar.html
+help:anchor='foo'%20bookID=Vendor%20Help
+/help/foo/bar.html"
+*End
+*fr.cupsIPPReason foo/La Foo Reason: "text:La%20Long%20
+text:Foo%20Reason
+http://foo/fr/bar.html
+help:anchor='foo'%20bookID=Vendor%20Help
+/help/fr/foo/bar.html"
+*End
+*zh_TW.cupsIPPReason foo/Number 1 Foo Reason: "text:Number%201%20
+text:Foo%20Reason
+http://foo/zh_TW/bar.html
+help:anchor='foo'%20bookID=Vendor%20Help
+/help/zh_TW/foo/bar.html"
+*End
+*zh.cupsIPPReason foo/Number 2 Foo Reason: "text:Number%202%20
+text:Foo%20Reason
+http://foo/zh/bar.html
+help:anchor='foo'%20bookID=Vendor%20Help
+/help/zh/foo/bar.html"
+*End
+
+*% Marker names for ppdLocalizeMarkerName tests
+*cupsMarkerName cyan/Cyan Toner: ""
+*fr.cupsMarkerName cyan/La Toner Cyan: ""
+*zh_TW.cupsMarkerName cyan/Number 1 Cyan Toner: ""
+*zh.cupsMarkerName cyan/Number 2 Cyan Toner: ""
+
+*DefaultFont: Courier
+*Font AvantGarde-Book: Standard "(001.006S)" Standard ROM
+*Font AvantGarde-BookOblique: Standard "(001.006S)" Standard ROM
+*Font AvantGarde-Demi: Standard "(001.007S)" Standard ROM
+*Font AvantGarde-DemiOblique: Standard "(001.007S)" Standard ROM
+*Font Bookman-Demi: Standard "(001.004S)" Standard ROM
+*Font Bookman-DemiItalic: Standard "(001.004S)" Standard ROM
+*Font Bookman-Light: Standard "(001.004S)" Standard ROM
+*Font Bookman-LightItalic: Standard "(001.004S)" Standard ROM
+*Font Courier: Standard "(002.004S)" Standard ROM
+*Font Courier-Bold: Standard "(002.004S)" Standard ROM
+*Font Courier-BoldOblique: Standard "(002.004S)" Standard ROM
+*Font Courier-Oblique: Standard "(002.004S)" Standard ROM
+*Font Helvetica: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Bold: Standard "(001.007S)" Standard ROM
+*Font Helvetica-BoldOblique: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Narrow-Bold: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow-BoldOblique: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow-Oblique: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Oblique: Standard "(001.006S)" Standard ROM
+*Font NewCenturySchlbk-Bold: Standard "(001.009S)" Standard ROM
+*Font NewCenturySchlbk-BoldItalic: Standard "(001.007S)" Standard ROM
+*Font NewCenturySchlbk-Italic: Standard "(001.006S)" Standard ROM
+*Font NewCenturySchlbk-Roman: Standard "(001.007S)" Standard ROM
+*Font Palatino-Bold: Standard "(001.005S)" Standard ROM
+*Font Palatino-BoldItalic: Standard "(001.005S)" Standard ROM
+*Font Palatino-Italic: Standard "(001.005S)" Standard ROM
+*Font Palatino-Roman: Standard "(001.005S)" Standard ROM
+*Font Symbol: Special "(001.007S)" Special ROM
+*Font Times-Bold: Standard "(001.007S)" Standard ROM
+*Font Times-BoldItalic: Standard "(001.009S)" Standard ROM
+*Font Times-Italic: Standard "(001.007S)" Standard ROM
+*Font Times-Roman: Standard "(001.007S)" Standard ROM
+*Font ZapfChancery-MediumItalic: Standard "(001.007S)" Standard ROM
+*Font ZapfDingbats: Special "(001.004S)" Standard ROM

--- a/ppd/testppd.c
+++ b/ppd/testppd.c
@@ -1163,7 +1163,22 @@ main(int  argc,				// I - Number of command-line arguments
     }
 
     status += do_ps_tests();
+  
+  fputs("ppdCacheCreateWithPPD(sbo_test.ppd - overflow regression): ", 
+        stdout);
+  if ((ppd = ppdOpenFile("ppd/sbo_test.ppd")) != NULL)
+  {
+    pc = ppdCacheCreateWithPPD(ppd);
+    if (pc)
+    ppdCacheDestroy(pc);
+    puts("PASS");
   }
+    else
+      {
+        puts("FAIL (Unable to open PPD)");
+        status ++;
+      }
+    }
   else if (!strcmp(argv[1], "--raster"))
   {
     for (status = 0, num_options = 0, options = NULL, i = 1; i < argc; i ++)


### PR DESCRIPTION
Added a check for the return value of pwgFormatSizeName() to avoid continuing with an empty buffer.
Also added the crash PPD file (sbo_test.ppd) and a regression test in testppd.c that opens it and calls ppdCacheCreateWithPPD().
This ensures make check catches the issue if it ever breaks again. All tests are passing.
Fixes #69 