### PR TITLE
Fix: ppdLutLoad() returning NULL due to undersized spec buffer

### DIFF
--- a/ppd/ppd-load-profile.c
+++ b/ppd/ppd-load-profile.c
@@ -131,7 +131,7 @@ ppdLutLoad(ppd_file_t *ppd,		// I - PPD file
 	    void       *ld)             // I - Log function data
 {
   char		name[PPD_MAX_NAME],	// Attribute name
-		spec[PPD_MAX_NAME];	// Attribute spec
+		spec[IPP_MAX_NAME];	// Attribute spec
   ppd_attr_t	*attr;			// Attribute
   int		nvals;			// Number of values
   float		vals[4];		// Values


### PR DESCRIPTION
 ## Problem

  `ppdLutLoad()` in `ppd/ppd-load-profile.c` declares its `spec[]` buffer as `PPD_MAX_NAME` (41 bytes), then passes that buffer to `ppdFindColorAttr()`. But `ppdFindColorAttr()`
  rejects any caller whose `specsize < IPP_MAX_NAME` (256 bytes):

  ```c
  // ppd/ppd-load-profile.c (current master), lines 55-57
  if (!ppd || !name || !colormodel || !media || !resolution || !spec ||
      specsize < IPP_MAX_NAME)
    return (NULL);
  ```

  As a result, **every call to `ppdLutLoad()` returns NULL** — the function is effectively dead code on `master`. Any printer driver that relies on `cups*Dither` /
  `cupsAllDither` PPD attributes for halftone LUT loading silently gets no LUT.

  The sibling functions in the same file (`ppdRGBLoad()` at line 193, `ppdCMYKLoad()` at line 311) already declare their `spec[]` buffer as `IPP_MAX_NAME`, so this is clearly an
  oversight in `ppdLutLoad()` alone.

  ## Fix

  Change one character — make `ppdLutLoad`'s `spec` buffer `IPP_MAX_NAME` to match what `ppdFindColorAttr()` requires.

  ```diff
     char               name[PPD_MAX_NAME],     // Attribute name
  -             spec[PPD_MAX_NAME];     // Attribute spec
  +             spec[IPP_MAX_NAME];     // Attribute spec
  ```

  No API change, no behaviour change for callers that were already getting NULL — they now get the LUT the function was always meant to return.