### PR TITLE
Build and test against CUPS 2.4, 2.5 and 3.x across 4 architectures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,36 +1,18 @@
 # =============================================================================
-# Multi-Architecture Build & Test Workflow for libppd
+# Multi-Architecture / multi-CUPS Build & Test Workflow for libppd
 #
-# Modelled on the QEMU-based CI used in the sister OpenPrinting repositories
-# (libcupsfilters, cups-filters).  Proves on every push / PR / manual dispatch
-# that libppd compiles end-to-end (libppd.la + every check_PROGRAMS binary)
-# and that every registered TEST in Makefile.am passes under
-# `make check V=1 VERBOSE=1` on FOUR architectures:
+# Matrix: 4 architectures x 3 CUPS releases = 12 combinations.
+#   architectures: amd64, arm64 (native runners); armhf, riscv64 (QEMU)
+#   CUPS releases: 2.4.x (distro libcups2-dev), 2.5.x (OpenPrinting/cups
+#                  master), 3.x (OpenPrinting/libcups master)
 #
-#   * amd64    - native, ubuntu-latest
-#   * arm64    - native, ubuntu-24.04-arm
-#   * armhf    - emulated via QEMU (armv7)
-#   * riscv64  - emulated via QEMU
-#
-# The hermetic C unit tests exercised: testppd, test_ppd_localize,
-# test_ppd_cache, test_ppd_ipp, test_ppd_mark, test_ppd_custom,
-# test_ppd_attr, test_ppd_page, test_ppd_conflicts.
-#
-# apt package list derived from libppd's configure.ac:
-#   PKG_CHECK_MODULES([LIBCUPSFILTERS])     -> libcupsfilters-dev
-#   PKG_CHECK_MODULES([ZLIB])               -> zlib1g-dev
-#   AC_PATH_TOOL(CUPSCONFIG)                -> libcups2-dev
-#   AC_CHECK_PROG(gs / pdftops / mutool)    -> ghostscript, poppler-utils,
-#                                              mupdf-tools
-#   AM_GNU_GETTEXT([external])              -> gettext, autopoint
-#   AC_PROG_CC / CXX / LT_INIT / pkg-config -> build-essential, autoconf,
-#                                              automake, libtool,
-#                                              libtool-bin, pkg-config
-#   transitive (poppler / qpdf renderers)   -> libqpdf-dev, libpoppler-dev,
-#                                              libpoppler-cpp-dev
+# libppd depends on BOTH libcups and libcupsfilters.  For the source-CUPS legs
+# the distro libcupsfilters-dev is the wrong ABI, so ci/ci-setup.sh builds
+# libcupsfilters (and pdfio) from source against the active CUPS.  All the
+# per-combination work lives in that script so the legs differ only in which
+# CUPS is provided and whether they run under emulation.
 # =============================================================================
-
-name: Build and Test (libppd, multi-arch)
+name: Build and Test (libppd, Multi-Architecture, Multi-CUPS)
 
 on:
   push:
@@ -41,14 +23,22 @@ on:
       - '**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
-    name: Build & Test (${{ matrix.arch }})
+  build-matrix:
+    name: Build & Test (${{ matrix.arch }}, ${{ matrix.cups }})
     runs-on: ${{ matrix.runs-on }}
+    # Building CUPS / libcupsfilters from source under QEMU is slow; allow plenty.
+    timeout-minutes: 360
 
     strategy:
       fail-fast: false
       matrix:
+        arch: [amd64, arm64, armhf, riscv64]
+        cups: [system-2x, source-2.5.x, source-3.x]
         include:
           - arch: amd64
             runs-on: ubuntu-latest
@@ -66,156 +56,80 @@ jobs:
             qemu-arch: riscv64
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Save workspace directory
-        run: echo "REPO_DIR=$(pwd)" >> $GITHUB_ENV
-
-      # -----------------------------------------------------------------------
-      # NATIVE LEG  (amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm)
-      # -----------------------------------------------------------------------
-      - name: Install dependencies (native)
+      # ==========================================
+      # NATIVE EXECUTION (amd64 and arm64)
+      # ==========================================
+      - name: Build & Test (Native)
         if: matrix.use-qemu == false
+        env:
+          CUPS_KIND: ${{ matrix.cups }}
+          EMULATED: "0"
         run: |
           set -ex
-          sudo apt-get clean
-          sudo apt-get update --fix-missing -y -o Acquire::Retries=3
-          # Drop any pre-shipped libppd-dev so our local build wins
-          sudo apt-get remove -y libppd-dev || true
-          sudo apt-get install -y --no-install-recommends \
-            build-essential \
-            autoconf \
-            automake \
-            autopoint \
-            libtool \
-            libtool-bin \
-            pkg-config \
-            gettext \
-            git \
-            wget \
-            tar \
-            libcups2-dev \
-            libcupsfilters-dev \
-            libqpdf-dev \
-            libpoppler-dev \
-            libpoppler-cpp-dev \
-            zlib1g-dev \
-            ghostscript \
-            poppler-utils \
-            mupdf-tools \
-            file
-
-      - name: Build & test libppd (native)
-        if: matrix.use-qemu == false
-        run: |
-          set -ex
-          cd "$REPO_DIR"
-          ./autogen.sh
-          # --enable-ppdc-utils: the downstream libppd-2-dev autopkgtest needs
-          # the staged `ppdc` to compile its test.drv into a PPD.
-          ./configure --enable-ppdc-utils
-          make -j$(nproc) V=1
-          make check V=1 VERBOSE=1 || {
-            echo "==== test-suite.log ===="
-            test -f test-suite.log && cat test-suite.log
-            echo "==== per-test logs ===="
-            for f in $(find . -name '*.log' -not -name 'config.log'); do
-              echo "---- $f ----"; cat "$f"
-            done
-            exit 1
-          }
+          sh ci/ci-setup.sh deps
+          sh ci/ci-setup.sh cups "${{ matrix.cups }}"
+          sh ci/ci-setup.sh pdfio
+          sh ci/ci-setup.sh libcupsfilters "${{ matrix.cups }}"
+          sh ci/ci-setup.sh build-libppd
 
       - name: Autopkgtest (DESTDIR staging, native)
+        # Run the downstream autopkgtest suite (libppd-2-dev compile/link/run +
+        # libppd-2-ppd-handling) against every CUPS version under test.
         if: matrix.use-qemu == false
         run: |
           set -ex
-          cd "$REPO_DIR"
-          # Full downstream suite: libppd-2-dev (compile/link/run) +
-          # libppd-2-ppd-handling.  Both point at the staged tree via
-          # environment overrides, so no privilege or path redirection is
-          # needed.
           make test-autopkgtest V=1
 
-      # -----------------------------------------------------------------------
-      # EMULATED LEG  (armhf via QEMU armv7, riscv64 via QEMU)
-      # -----------------------------------------------------------------------
-      - name: Set up QEMU
-        if: matrix.use-qemu == true
-        uses: docker/setup-qemu-action@v3
+      - name: Upload test artifacts (Native)
+        if: matrix.use-qemu == false && always()
+        continue-on-error: true
+        timeout-minutes: 5
+        uses: actions/upload-artifact@v4
         with:
-          platforms: ${{ matrix.qemu-arch }}
+          name: libppd-logs-${{ matrix.arch }}-${{ matrix.cups }}
+          path: |
+            config.log
+            test-suite.log
+            ppd/*.log
+            ppd/*.trs
+          if-no-files-found: ignore
 
-      - name: Build & test libppd (emulated)
+      # ==========================================
+      # EMULATED EXECUTION (armhf and riscv64)
+      # ==========================================
+      - name: Build & Test (Emulated)
         if: matrix.use-qemu == true
         uses: uraimo/run-on-arch-action@v3
         with:
           arch: ${{ matrix.qemu-arch }}
           distro: ubuntu24.04
-          dockerRunArgs: |
-            --volume "${{ github.workspace }}:/workspace"
+          githubToken: ${{ github.token }}
           install: |
-            apt-get clean
-            apt-get update --fix-missing -y -o Acquire::Retries=3
-            DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
-            apt-get remove -y libppd-dev 2>/dev/null || true
-            apt-get install -y --no-install-recommends \
-              build-essential \
-              gcc g++ \
-              autoconf \
-              automake \
-              autopoint \
-              libtool \
-              libtool-bin \
-              pkg-config \
-              gettext \
-              git \
-              wget \
-              tar \
-              libcups2-dev \
-              libcupsfilters-dev \
-              libqpdf-dev \
-              libpoppler-dev \
-              libpoppler-cpp-dev \
-              zlib1g-dev \
-              ghostscript \
-              poppler-utils \
-              mupdf-tools \
-              file
+            apt-get update --fix-missing -y
+            DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata ca-certificates git
           run: |
             set -ex
-            cd /workspace
-            ./autogen.sh
-            # --enable-ppdc-utils: needed by the libppd-2-dev autopkgtest.
-            ./configure --enable-ppdc-utils
-            make -j$(nproc) V=1
-            make check V=1 VERBOSE=1 || {
-              echo "==== test-suite.log ===="
-              test -f test-suite.log && cat test-suite.log
-              echo "==== per-test logs ===="
-              for f in $(find . -name '*.log' -not -name 'config.log'); do
-                echo "---- $f ----"; cat "$f"
-              done
-              exit 1
-            }
-
-            # Full downstream autopkgtest suite.  Both tests resolve the
-            # staged build tree through environment overrides (no absolute
-            # paths, no privilege, no bind mounts), so the same suite that
-            # runs on the native legs runs unchanged under QEMU emulation.
+            export CUPS_KIND="${{ matrix.cups }}"
+            export EMULATED=1
+            sh ci/ci-setup.sh deps
+            sh ci/ci-setup.sh cups "${{ matrix.cups }}"
+            sh ci/ci-setup.sh pdfio
+            sh ci/ci-setup.sh libcupsfilters "${{ matrix.cups }}"
+            sh ci/ci-setup.sh build-libppd
             make test-autopkgtest V=1
 
-      # -----------------------------------------------------------------------
-      # ARTIFACT UPLOAD (all four legs, only on failure)
-      # -----------------------------------------------------------------------
-      - name: Upload test logs on failure
-        if: failure()
+      - name: Upload test artifacts (Emulated)
+        if: matrix.use-qemu == true && always()
+        continue-on-error: true
+        timeout-minutes: 5
         uses: actions/upload-artifact@v4
         with:
-          name: libppd-test-logs-${{ matrix.arch }}
+          name: libppd-logs-${{ matrix.arch }}-${{ matrix.cups }}
           path: |
+            config.log
             test-suite.log
-            **/*.log
-            **/*.trs
-          if-no-files-found: warn
-          retention-days: 14
+            ppd/*.log
+            ppd/*.trs
+          if-no-files-found: ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Emulated arches (armhf, riscv64) are temporarily disabled to iterate
-        # on the fast native legs first; re-enable them (matrix entry + include
-        # block below) once amd64/arm64 are green on all three CUPS releases.
-        arch: [amd64, arm64]
+        arch: [amd64, arm64, armhf, riscv64]
         cups: [system-2x, source-2.5.x, source-3.x]
         include:
           - arch: amd64
@@ -49,14 +46,14 @@ jobs:
           - arch: arm64
             runs-on: ubuntu-24.04-arm
             use-qemu: false
-          # - arch: armhf
-          #   runs-on: ubuntu-latest
-          #   use-qemu: true
-          #   qemu-arch: armv7
-          # - arch: riscv64
-          #   runs-on: ubuntu-latest
-          #   use-qemu: true
-          #   qemu-arch: riscv64
+          - arch: armhf
+            runs-on: ubuntu-latest
+            use-qemu: true
+            qemu-arch: armv7
+          - arch: riscv64
+            runs-on: ubuntu-latest
+            use-qemu: true
+            qemu-arch: riscv64
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, arm64, armhf, riscv64]
+        # Emulated arches (armhf, riscv64) are temporarily disabled to iterate
+        # on the fast native legs first; re-enable them (matrix entry + include
+        # block below) once amd64/arm64 are green on all three CUPS releases.
+        arch: [amd64, arm64]
         cups: [system-2x, source-2.5.x, source-3.x]
         include:
           - arch: amd64
@@ -46,14 +49,14 @@ jobs:
           - arch: arm64
             runs-on: ubuntu-24.04-arm
             use-qemu: false
-          - arch: armhf
-            runs-on: ubuntu-latest
-            use-qemu: true
-            qemu-arch: armv7
-          - arch: riscv64
-            runs-on: ubuntu-latest
-            use-qemu: true
-            qemu-arch: riscv64
+          # - arch: armhf
+          #   runs-on: ubuntu-latest
+          #   use-qemu: true
+          #   qemu-arch: armv7
+          # - arch: riscv64
+          #   runs-on: ubuntu-latest
+          #   use-qemu: true
+          #   qemu-arch: riscv64
 
     steps:
       - uses: actions/checkout@v4

--- a/Makefile.am
+++ b/Makefile.am
@@ -315,8 +315,13 @@ genstrings_SOURCES = \
 genstrings_LDADD = \
 	libppd.la \
 	$(CUPS_LIBS)
-genstrings_CFLAGS = \
+# These utilities are built from C++ (.cxx) sources, so their per-target
+# compiler flags must be *_CXXFLAGS - Automake ignores *_CFLAGS for C++.
+# Without this the CUPS include path is dropped, which only fails for a
+# source-installed CUPS whose headers are not in the default search path.
+genstrings_CXXFLAGS = \
 	-I$(srcdir)/ppd/ \
+	$(LIBCUPSFILTERS_CFLAGS) \
 	$(CUPS_CFLAGS)
 
 ppdc_SOURCES = \
@@ -324,8 +329,9 @@ ppdc_SOURCES = \
 ppdc_LDADD = \
 	libppd.la \
 	$(CUPS_LIBS)
-ppdc_CFLAGS = \
+ppdc_CXXFLAGS = \
 	-I$(srcdir)/ppd/ \
+	$(LIBCUPSFILTERS_CFLAGS) \
 	$(CUPS_CFLAGS)
 
 ppdhtml_SOURCES = \
@@ -333,8 +339,9 @@ ppdhtml_SOURCES = \
 ppdhtml_LDADD = \
 	libppd.la \
 	$(CUPS_LIBS)
-ppdhtml_CFLAGS = \
+ppdhtml_CXXFLAGS = \
 	-I$(srcdir)/ppd/ \
+	$(LIBCUPSFILTERS_CFLAGS) \
 	$(CUPS_CFLAGS)
 
 ppdi_SOURCES = \
@@ -342,8 +349,9 @@ ppdi_SOURCES = \
 ppdi_LDADD = \
 	libppd.la \
 	$(CUPS_LIBS)
-ppdi_CFLAGS = \
+ppdi_CXXFLAGS = \
 	-I$(srcdir)/ppd/ \
+	$(LIBCUPSFILTERS_CFLAGS) \
 	$(CUPS_CFLAGS)
 
 ppdmerge_SOURCES = \
@@ -351,8 +359,9 @@ ppdmerge_SOURCES = \
 ppdmerge_LDADD = \
 	libppd.la \
 	$(CUPS_LIBS)
-ppdmerge_CFLAGS = \
+ppdmerge_CXXFLAGS = \
 	-I$(srcdir)/ppd/ \
+	$(LIBCUPSFILTERS_CFLAGS) \
 	$(CUPS_CFLAGS)
 
 ppdpo_SOURCES = \
@@ -360,8 +369,9 @@ ppdpo_SOURCES = \
 ppdpo_LDADD = \
 	libppd.la \
 	$(CUPS_LIBS)
-ppdpo_CFLAGS = \
+ppdpo_CXXFLAGS = \
 	-I$(srcdir)/ppd/ \
+	$(LIBCUPSFILTERS_CFLAGS) \
 	$(CUPS_CFLAGS)
 
 distclean-local:

--- a/Makefile.am
+++ b/Makefile.am
@@ -426,6 +426,16 @@ install-test-data:
 	  echo "  STAGE   $$f -> $(CIROOT)$(datadir)/ppd/testppd/"; \
 	  $(INSTALL_DATA) "$(srcdir)/$$f" "$(CIROOT)$(datadir)/ppd/testppd/" || exit 1; \
 	done
+	@# The libppd-2-dev test exercises the text -> PDF path, whose texttopdf
+	@# filter (from libcupsfilters) reads charsets/pdf.<charset> from the CUPS
+	@# data directory.  The wrapper points CUPS_DATADIR at the staging tree, so
+	@# seed the charset data (installed by libcupsfilters into the real
+	@# $(CUPS_DATADIR)/charsets) into the staged tree.
+	@if [ -d "$(CUPS_DATADIR)/charsets" ]; then \
+	  echo "  STAGE   $(CUPS_DATADIR)/charsets -> $(CIROOT)$(datadir)/charsets/"; \
+	  $(MKDIR_P) "$(CIROOT)$(datadir)/charsets"; \
+	  cp -a "$(CUPS_DATADIR)/charsets/." "$(CIROOT)$(datadir)/charsets/" || exit 1; \
+	fi
 
 # Build everything, DESTDIR-install it, top up the test-only programs/data,
 # then rewrite the staged libppd.pc prefix so a downstream consumer resolves

--- a/ci/ci-setup.sh
+++ b/ci/ci-setup.sh
@@ -1,0 +1,185 @@
+#!/bin/sh
+# ci/ci-setup.sh
+#
+# CI helper for building libppd against several CUPS releases on both native
+# and QEMU-emulated runners.  The same source compiles against CUPS 2.4.x,
+# 2.5.x and 3.x; this script provides each of those CUPS builds (and a matching
+# libcupsfilters) and then builds and tests libppd against it.
+#
+# libppd depends on BOTH libcups and libcupsfilters, so for the source-CUPS
+# legs the distro libcupsfilters-dev (built against CUPS 2.4) is the wrong ABI;
+# this script builds libcupsfilters from source against the active CUPS instead.
+#
+# Subcommands:
+#   deps                 install build dependencies
+#   cups <kind>          provide libcups; <kind> is one of:
+#                          system-2x    distro libcups2-dev  (CUPS 2.4.x)
+#                          source-2.5.x OpenPrinting/cups@master    (CUPS 2.5.x)
+#                          source-3.x   OpenPrinting/libcups@master (libcups3)
+#   pdfio                build/install pdfio (required by libcupsfilters)
+#   libcupsfilters <kind> provide libcupsfilters matching the active CUPS:
+#                          system-2x    distro libcupsfilters-dev
+#                          source-*     OpenPrinting/libcupsfilters@master
+#   build-libppd         autogen + configure + make + make check
+#
+# Environment knobs honoured by build-libppd:
+#   CUPS_KIND   the <kind> above (controls test XFAILs for source CUPS)
+#   EMULATED    "1" when running under QEMU emulation (controls test XFAILs)
+#
+# Override knobs (optional):
+#   LIBCUPSFILTERS_URL  git URL for the source libcupsfilters build
+#   LIBCUPSFILTERS_REF  git ref for the source libcupsfilters build
+#
+# The script runs as root inside emulation containers and via sudo on native
+# runners; it detects which automatically.
+set -eu
+
+PDFIO_VER=1.6.4
+LIBCUPSFILTERS_URL="${LIBCUPSFILTERS_URL:-https://github.com/OpenPrinting/libcupsfilters.git}"
+LIBCUPSFILTERS_REF="${LIBCUPSFILTERS_REF:-master}"
+
+SUDO=""
+[ "$(id -u)" -eq 0 ] || SUDO="sudo"
+
+# Make apt completely non-interactive.  Native GitHub runners ship needrestart,
+# whose service-restart prompt otherwise hangs the job forever; the emulated
+# containers do not have it, which is why only the native legs stalled.
+export DEBIAN_FRONTEND=noninteractive
+export NEEDRESTART_MODE=a
+export NEEDRESTART_SUSPEND=1
+
+# Source-built CUPS / libcupsfilters install their .pc files under
+# $prefix/lib[/<multiarch>]/pkgconfig; make sure pkg-config (and therefore
+# libppd's configure) can find them.
+ma=$(gcc -dumpmachine 2>/dev/null || echo "")
+PKG_CONFIG_PATH="/usr/lib/pkgconfig${ma:+:/usr/lib/$ma/pkgconfig}:/usr/local/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+export PKG_CONFIG_PATH
+
+apt_install() {
+	$SUDO apt-get update --fix-missing -y
+	$SUDO apt-get install -y "$@"
+}
+
+cmd_deps() {
+	# Union of libppd's own build deps and the deps needed to build
+	# libcupsfilters and pdfio from source on the source-CUPS legs.
+	apt_install \
+		build-essential autoconf automake libtool libtool-bin pkg-config \
+		gettext autopoint autotools-dev cmake git wget tar make gcc g++ \
+		file dbus \
+		libavahi-client-dev libssl-dev libpam-dev libusb-1.0-0-dev \
+		zlib1g-dev libqpdf-dev libexif-dev liblcms2-dev libfontconfig1-dev \
+		libfreetype6-dev libcairo2-dev libjpeg-dev libpng-dev libtiff-dev \
+		libjxl-dev libpoppler-dev libpoppler-cpp-dev libdbus-1-dev \
+		libopenjp2-7-dev mupdf-tools poppler-utils ghostscript
+	# Never let pre-shipped libppd / libcupsfilters shadow the builds under test.
+	$SUDO apt-get remove -y libppd-dev libcupsfilters-dev || true
+}
+
+# build_autoconf <url> <ref> <submodule-flag> [configure-args...]
+build_autoconf() {
+	url="$1"; ref="$2"; sub="$3"; shift 3
+	echo "ci-setup: building $url @ $ref"
+	src="$(mktemp -d)"
+	git clone --depth 1 --branch "$ref" $sub "$url" "$src"
+	( cd "$src"
+	  [ -x ./configure ] || ./autogen.sh
+	  ./configure --prefix=/usr "$@" || ./configure --prefix=/usr
+	  make -j"$(nproc)"
+	  $SUDO make install )
+	$SUDO ldconfig || true
+}
+
+cmd_cups() {
+	kind="$1"
+	case "$kind" in
+		system-2x)
+			apt_install libcups2-dev
+			;;
+		source-2.5.x)
+			# CUPS 2.5 (OpenPrinting/cups master) ships cups.pc and has
+			# dropped cups-config; libppd's configure now detects it via
+			# pkg-config, so no cups-config shim is needed.
+			#
+			# Force the multiarch libdir: CUPS's configure otherwise installs
+			# libcups into /usr/lib64 on 64-bit hosts, which is not on the
+			# default linker search path.  A downstream consumer that links
+			# only "-lppd" must be able to find libcups transitively at link
+			# time - which only works if libcups sits in a default search dir.
+			build_autoconf https://github.com/OpenPrinting/cups.git master "" \
+				--disable-systemd ${ma:+--libdir=/usr/lib/$ma}
+			;;
+		source-3.x)
+			build_autoconf https://github.com/OpenPrinting/libcups.git master \
+				"--recurse-submodules"
+			;;
+		*)
+			echo "ci-setup: unknown cups kind: $kind" >&2; exit 2 ;;
+	esac
+}
+
+cmd_pdfio() {
+	echo "ci-setup: building pdfio $PDFIO_VER"
+	src="$(mktemp -d)"
+	( cd "$src"
+	  wget -q "https://github.com/michaelrsweet/pdfio/releases/download/v$PDFIO_VER/pdfio-$PDFIO_VER.tar.gz"
+	  tar -xzf "pdfio-$PDFIO_VER.tar.gz"
+	  cd "pdfio-$PDFIO_VER"
+	  ./configure --prefix=/usr --enable-shared
+	  make all
+	  $SUDO make install )
+	$SUDO ldconfig || true
+}
+
+cmd_libcupsfilters() {
+	kind="$1"
+	case "$kind" in
+		system-2x)
+			apt_install libcupsfilters-dev
+			;;
+		source-*)
+			# Build libcupsfilters against the CUPS already installed above.
+			# Its configure auto-detects CUPS via pkg-config (cups3 / cups /
+			# cups-config), so the same source matches every CUPS release.
+			build_autoconf "$LIBCUPSFILTERS_URL" "$LIBCUPSFILTERS_REF" ""
+			;;
+		*)
+			echo "ci-setup: unknown libcupsfilters kind: $kind" >&2; exit 2 ;;
+	esac
+}
+
+cmd_build() {
+	./autogen.sh
+	# --enable-ppdc-utils: the downstream libppd-2-dev autopkgtest needs the
+	# staged `ppdc` to compile its test.drv into a PPD.
+	./configure --enable-ppdc-utils
+	make -j"$(nproc)" V=1
+
+	# Report which CUPS the configure step actually selected.
+	echo "ci-setup: configured against:"
+	grep -E "libcups:|cups-config:" config.log 2>/dev/null || true
+
+	# Hook for tests that depend on environment quirks of a source-installed
+	# or emulated CUPS.  Empty for now; add space-separated test names here if
+	# a leg surfaces an environment-only failure.
+	xfail=""
+
+	if [ -n "$xfail" ]; then
+		make check V=1 VERBOSE=1 XFAIL_TESTS="$xfail" \
+			|| { test -f test-suite.log && cat test-suite.log; exit 1; }
+	else
+		make check V=1 VERBOSE=1 \
+			|| { test -f test-suite.log && cat test-suite.log; exit 1; }
+	fi
+}
+
+case "${1:-}" in
+	deps)                 cmd_deps ;;
+	cups)                 shift; cmd_cups "$@" ;;
+	pdfio)                cmd_pdfio ;;
+	libcupsfilters)       shift; cmd_libcupsfilters "$@" ;;
+	build-libppd)         cmd_build ;;
+	*)
+		echo "usage: ci-setup.sh {deps | cups <kind> | pdfio | libcupsfilters <kind> | build-libppd}" >&2
+		exit 2 ;;
+esac

--- a/configure.ac
+++ b/configure.ac
@@ -94,6 +94,41 @@ AS_IF([$PKGCONFIG --exists cups3], [
     AC_DEFINE_UNQUOTED(CUPS_SERVERBIN, "$CUPS_SERVERBIN",
 		       [Path to CUPS binaries dir])
     AC_SUBST(CUPS_SERVERBIN)
+], [$PKGCONFIG --exists cups], [
+    # CUPS 2.5 ships cups.pc but has dropped cups-config.  It uses the
+    # libcups2 API names, so select the libcups2 compatibility path and
+    # derive the install locations from the pkg-config prefix.
+    AC_MSG_RESULT(no)
+    AC_MSG_CHECKING([for CUPS library v2.5 via pkg-config])
+    CUPS_VERSION="$($PKGCONFIG --modversion cups)"
+    AC_MSG_RESULT([yes, v$CUPS_VERSION])
+    AC_DEFINE([HAVE_LIBCUPS2], [1], [Use libcups2])
+    CUPS_CFLAGS="$($PKGCONFIG --cflags cups)"
+    CUPS_LIBS="$LIBS $($PKGCONFIG --libs cups)"
+    AC_SUBST(CUPS_CFLAGS)
+    AC_SUBST(CUPS_LIBS)
+    CUPS_DATADIR="$($PKGCONFIG --variable=prefix cups)/share/cups"
+    AC_DEFINE_UNQUOTED(CUPS_DATADIR, "$CUPS_DATADIR", [CUPS datadir])
+    AC_SUBST(CUPS_DATADIR)
+    AS_IF([test x$host_os_name = xdarwin], [
+	CUPS_SERVERROOT="/private/etc/cups"
+    ], [
+	AS_IF([test "x$($PKGCONFIG --variable=prefix cups)" = x/usr], [
+	    CUPS_SERVERROOT="/etc/cups"
+	], [
+	    CUPS_SERVERROOT="$($PKGCONFIG --variable=prefix cups)/etc/cups"
+	])
+    ])
+    AC_DEFINE_UNQUOTED(CUPS_SERVERROOT, "$CUPS_SERVERROOT", [CUPS serverroot])
+    AC_SUBST(CUPS_SERVERROOT)
+    CUPS_FONTPATH="$CUPS_DATADIR/fonts"
+    AC_DEFINE_UNQUOTED(CUPS_FONTPATH, "$CUPS_FONTPATH",
+		       [Path to CUPS fonts dir])
+    AC_SUBST(CUPS_FONTPATH)
+    CUPS_SERVERBIN="$($PKGCONFIG --variable=prefix cups)/lib/cups"
+    AC_DEFINE_UNQUOTED(CUPS_SERVERBIN, "$CUPS_SERVERBIN",
+		       [Path to CUPS binaries dir])
+    AC_SUBST(CUPS_SERVERBIN)
 ], [
     AC_MSG_RESULT(no)
     AC_ARG_WITH([cups-config],

--- a/libppd.pc.in
+++ b/libppd.pc.in
@@ -9,4 +9,4 @@ Version: @VERSION@
 
 Libs: -L${libdir} -lppd
 Libs.private: @CUPS_LIBS@
-Cflags: -I${includedir} -I${includedir}/ppd
+Cflags: -I${includedir} -I${includedir}/ppd @CUPS_CFLAGS@

--- a/ppd/libcups2-private.h
+++ b/ppd/libcups2-private.h
@@ -64,6 +64,17 @@ extern "C" {
 #    define ippGetNextAttribute    ippNextAttribute
 #    define ippGetLength           ippLength
 
+//   Option parser: libcups3 spells it cupsParseOptions() with a trailing
+//   "end" pointer.  CUPS 2.5 provides the same 4-argument parser under the
+//   historic name cupsParseOptions2(); CUPS 2.4 only has the 3-argument form,
+//   so the "end" argument is dropped there.
+
+#    if CUPS_VERSION_MINOR >= 5
+#      define cupsParseOptions cupsParseOptions2
+#    else
+#      define cupsParseOptions(arg, end, num_options, options) cupsParseOptions(arg, num_options, options)
+#    endif
+
 //   Functions replaced by a different functions in libcups3
 
 #    define cupsCreateTempFd(prefix,suffix,buffer,bufsize) cupsTempFd(buffer,bufsize)

--- a/ppd/libcups2-private.h
+++ b/ppd/libcups2-private.h
@@ -99,7 +99,7 @@ extern "C" {
 //   NB: libcups3 defines its own enum named cups_bool_t (in cups/raster.h),
 //   so this private alias must NOT reuse that name.
 
-#    define ppd_cups_bool_t        int
+#    define ppd_bool_t             int
 
 //   Prototypes of functions equivalent to newly introduced ones in libcups3
 
@@ -114,7 +114,7 @@ const char *cupsLangGetString(cups_lang_t *lang, const char *message);
 
 #    define cups_len_t            size_t
 #    define cups_utf8_t           char
-#    define ppd_cups_bool_t        bool
+#    define ppd_bool_t             bool
 
 #  endif // HAVE_LIBCUPS2
 

--- a/ppd/libcups2-private.h
+++ b/ppd/libcups2-private.h
@@ -96,8 +96,10 @@ extern "C" {
 
 //   For some functions' parameters in libcups3 bool is used while
 //   int was used in libcups2. We use this type in such a case.
+//   NB: libcups3 defines its own enum named cups_bool_t (in cups/raster.h),
+//   so this private alias must NOT reuse that name.
 
-#    define cups_bool_t           int
+#    define ppd_cups_bool_t        int
 
 //   Prototypes of functions equivalent to newly introduced ones in libcups3
 
@@ -112,7 +114,7 @@ const char *cupsLangGetString(cups_lang_t *lang, const char *message);
 
 #    define cups_len_t            size_t
 #    define cups_utf8_t           char
-#    define cups_bool_t           bool
+#    define ppd_cups_bool_t        bool
 
 #  endif // HAVE_LIBCUPS2
 

--- a/ppd/ppd-cache.c
+++ b/ppd/ppd-cache.c
@@ -3672,7 +3672,7 @@ ppdCacheGetInputSlot(
     ipp_attribute_t	*media_col,	// media-col attribute
 			*media_source;	// media-source attribute
     pwg_size_t		size;		// Dimensional size
-    ppd_cups_bool_t	margins_set;	// Were the margins set?
+    ppd_bool_t	margins_set;	// Were the margins set?
 
     media_col = ippFindAttribute(job, "media-col", IPP_TAG_BEGIN_COLLECTION);
     if (media_col &&
@@ -3811,7 +3811,7 @@ ppdCacheGetPageSize(
 		*variant,		// Page size variant
 		*closest,		// Closest size
 		jobsize;		// Size data from job
-  ppd_cups_bool_t margins_set;		// Were the margins set?
+  ppd_bool_t margins_set;		// Were the margins set?
   int		dwidth,			// Difference in width
 		dlength,		// Difference in length
 		dleft,			// Difference in left margins

--- a/ppd/ppd-cache.c
+++ b/ppd/ppd-cache.c
@@ -3672,7 +3672,7 @@ ppdCacheGetInputSlot(
     ipp_attribute_t	*media_col,	// media-col attribute
 			*media_source;	// media-source attribute
     pwg_size_t		size;		// Dimensional size
-    cups_bool_t		margins_set;	// Were the margins set?
+    ppd_cups_bool_t	margins_set;	// Were the margins set?
 
     media_col = ippFindAttribute(job, "media-col", IPP_TAG_BEGIN_COLLECTION);
     if (media_col &&
@@ -3811,7 +3811,7 @@ ppdCacheGetPageSize(
 		*variant,		// Page size variant
 		*closest,		// Closest size
 		jobsize;		// Size data from job
-  cups_bool_t	margins_set;		// Were the margins set?
+  ppd_cups_bool_t margins_set;		// Were the margins set?
   int		dwidth,			// Difference in width
 		dlength,		// Difference in length
 		dleft,			// Difference in left margins

--- a/ppd/ppd-cache.c
+++ b/ppd/ppd-cache.c
@@ -1072,7 +1072,7 @@ ppdCacheCreateWithFile(
       }
 
       pc->num_presets[print_color_mode][print_quality] =
-          cupsParseOptions(valueptr, 0,
+          cupsParseOptions(valueptr, NULL, 0,
 	                   pc->presets[print_color_mode] + print_quality);
     }
     else if (!_ppd_strcasecmp(line, "OptimizePreset"))
@@ -1095,7 +1095,7 @@ ppdCacheCreateWithFile(
       }
 
       pc->num_optimize_presets[print_content_optimize] =
-          cupsParseOptions(valueptr, 0,
+          cupsParseOptions(valueptr, NULL, 0,
 	                   pc->optimize_presets + print_content_optimize);
     }
     else if (!_ppd_strcasecmp(line, "SidesOption"))
@@ -1118,7 +1118,7 @@ ppdCacheCreateWithFile(
         goto create_error;
 
       finishings->value       = (ipp_finishings_t)strtol(value, &valueptr, 10);
-      finishings->num_options = cupsParseOptions(valueptr, 0,
+      finishings->num_options = cupsParseOptions(valueptr, NULL, 0,
                                                  &(finishings->options));
 
       cupsArrayAdd(pc->finishings, finishings);

--- a/ppd/ppd-filter.c
+++ b/ppd/ppd-filter.c
@@ -148,7 +148,8 @@ ppdFilterCUPSWrapper(
   {
     if ((val = getenv("CUPS_FONTPATH")) == NULL)
     {
-      val = CUPS_DATADIR;
+      if ((val = getenv("CUPS_DATADIR")) == NULL)
+	val = CUPS_DATADIR;
       snprintf(buf, sizeof(buf), "%s/fonts", val);
       val = buf;
     }

--- a/ppd/ppd-filter.c
+++ b/ppd/ppd-filter.c
@@ -112,7 +112,7 @@ ppdFilterCUPSWrapper(
 
   options     = NULL;
   if (argc > 5)
-    num_options = cupsParseOptions(argv[5], 0, &options);
+    num_options = cupsParseOptions(argv[5], NULL, 0, &options);
 
   if ((filter_data.printer = getenv("PRINTER")) == NULL)
     filter_data.printer = argv[0];

--- a/ppd/ppd-filter.c
+++ b/ppd/ppd-filter.c
@@ -1453,6 +1453,19 @@ ppdFilterUniversal(int inputfd,         // I - File descriptor input stream
 
 
   universal_parameters = *(cf_filter_universal_parameter_t *)parameters;
+
+  // texttopdf locates its charset files (charsets/pdf.<charset>) under the CUPS
+  // data directory.  Default it from the environment, as CUPS does, when the
+  // caller left it unset, so the filter never sees a NULL directory.
+  if (universal_parameters.texttopdf_params.data_dir == NULL)
+  {
+    char *datadir;			// CUPS data directory
+
+    if ((datadir = getenv("CUPS_DATADIR")) == NULL)
+      datadir = (char *)CUPS_DATADIR;
+    universal_parameters.texttopdf_params.data_dir = datadir;
+  }
+
   input = data->content_type;
   if (input == NULL)
   {

--- a/ppd/ppd-ipp.c
+++ b/ppd/ppd-ipp.c
@@ -95,7 +95,7 @@ ppdGetOptions(cups_option_t **options,	// O - Options
       // media-col value...
       //
 
-      num_media_col = cupsParseOptions(value, 0, &media_col);
+      num_media_col = cupsParseOptions(value, NULL, 0, &media_col);
     }
     else
     {
@@ -120,7 +120,7 @@ ppdGetOptions(cups_option_t **options,	// O - Options
     const char	*x_dimension,		// x-dimension value
 		*y_dimension;		// y-dimension value
 
-    num_media_size = cupsParseOptions(value, 0, &media_size);
+    num_media_size = cupsParseOptions(value, NULL, 0, &media_size);
 
     if ((x_dimension = cupsGetOption("x-dimension",
 				     num_media_size, media_size)) != NULL &&

--- a/ppd/ppd-mark.c
+++ b/ppd/ppd-mark.c
@@ -926,7 +926,7 @@ ppd_mark_option(ppd_file_t *ppd,	// I - PPD file
 
     if ((coption = ppdFindCustomOption(ppd, option)) != NULL)
     {
-      num_vals = cupsParseOptions(choice, 0, &vals);
+      num_vals = cupsParseOptions(choice, NULL, 0, &vals);
 
       for (i = 0, val = vals; i < num_vals; i ++, val ++)
       {

--- a/ppd/testppd.c
+++ b/ppd/testppd.c
@@ -1188,12 +1188,12 @@ main(int  argc,				// I - Number of command-line arguments
         if (argv[i][1] == 'o')
         {
           if (argv[i][2])
-            num_options = cupsParseOptions(argv[i] + 2, num_options, &options);
+            num_options = cupsParseOptions(argv[i] + 2, NULL, num_options, &options);
           else
           {
             i ++;
             if (i < argc)
-              num_options = cupsParseOptions(argv[i], num_options, &options);
+              num_options = cupsParseOptions(argv[i], NULL, num_options, &options);
             else
             {
               puts("Usage: testppd --raster [-o name=value ...] [filename.ppd ...]");

--- a/ppd/testppd.c
+++ b/ppd/testppd.c
@@ -824,6 +824,13 @@ main(int  argc,				// I - Number of command-line arguments
       printf("FAIL (\"%s\" instead of \"/help/foo/bar.html\")\n", buffer);
     }
 
+#ifdef HAVE_LIBCUPS2
+    // NB: these cases switch the locale at run time via putenv() and rely on
+    // cupsLangDefault() re-reading the environment on each call.  libcups3
+    // caches the default language, so a mid-process LANG change is not honoured
+    // there; skip them on libcups3.  The default-locale path above and the
+    // hermetic test_ppd_localize test still cover ppdLocalize*() on libcups3.
+
     // Force French
     putenv("LANG=fr");
     putenv("LC_ALL=fr");
@@ -855,6 +862,7 @@ main(int  argc,				// I - Number of command-line arguments
       status ++;
       printf("FAIL (\"%s\" instead of \"Number 1 Foo Reason\")\n", buffer);
     }
+#endif // HAVE_LIBCUPS2
 
     //
     // cupsMarkerName localization...
@@ -888,6 +896,8 @@ main(int  argc,				// I - Number of command-line arguments
              text ? text : "(null)");
     }
 
+#ifdef HAVE_LIBCUPS2
+    // Run-time locale switching (see note above); not honoured on libcups3.
     // Force French locale
     putenv("LANG=fr");
     putenv("LC_ALL=fr");
@@ -921,6 +931,7 @@ main(int  argc,				// I - Number of command-line arguments
       printf("FAIL (\"%s\" instead of \"Number 1 Cyan Toner\")\n",
              text ? text : "(null)");
     }
+#endif // HAVE_LIBCUPS2
 
     ppdClose(ppd);
 


### PR DESCRIPTION
This brings libppd up to the multi-CUPS testing standard: it now builds and passes its test suite against CUPS 2.4 (distro libcups2), CUPS 2.5 (OpenPrinting/cups master) and 3.x (OpenPrinting/libcups master), on amd64, arm64, armhf and riscv64 — a 12-combination CI matrix.

Since libppd needs libcupsfilters too, the source-CUPS legs build libcupsfilters (and pdfio) from master against the active CUPS.

  ## CI / build system
  - `.github/workflows/build.yml`: 4 arch × 3 CUPS matrix (amd64/arm64 native, armhf/riscv64 under QEMU); runs `make check` + the downstream DESTDIR autopkgtest for every combination.
  - `ci/ci-setup.sh`: per-combination setup — provisions each CUPS, pdfio and libcupsfilters from source where needed, then configures and tests libppd.
  - `configure.ac`: detect CUPS 2.5 via `pkg-config cups` (2.5 dropped cups-config), keeping the existing cups3 and cups-config paths.
  - `libppd.pc.in`: export `@CUPS_CFLAGS@` so downstream consumers find CUPS headers when CUPS is installed from source.

  ## Source-portability fixes
  - C++ utilities (ppdc, ppdhtml, ppdi, ppdmerge, ppdpo, genstrings) used  `*_CFLAGS`, which Automake ignores for C++ sources, dropping the CUPS include path on source-installed CUPS — switched to `*_CXXFLAGS`.
  - libcups3 now defines its own `cups_bool_t` enum, colliding with libppd's helper alias — renamed the alias to `ppd_bool_t`.
  - `cupsParseOptions()` is 4-arg on libcups3; added the translation in `libcups2-private.h` (2.5 → `cupsParseOptions2`, 2.4 → 3-arg form).

  ## Test-data / environment fixes
  - `ppdFilterUniversal` now defaults the text→PDF charset dir from `CUPS_DATADIR` (libcupsfilters master no longer falls back to it), and the test harness seeds the charset files into the staged data dir.
  - All CUPS directory macros (`CUPS_DATADIR`, fontpath) now check the matching env var before the compiled-in path, for sandboxed/relocated installs.
  - testppd's run-time `LANG`-switching localization cases are guarded for libcups2 only: libcups3's `cupsLangDefault()` caches the language, so mid-process locale switching no longer applies (test_ppd_localize still covers localization on libcups3).

## Notes for upstream review
  - libcupsfilters master texttopdf dropped its `CUPS_DATADIR` fallback — affects any caller that doesn't set the data dir.
  - libcups3 `cupsLangDefault()` caches the language; run-time locale switching is no longer honored.