### PR TITLE
Fix crash from wrong-tag output-bin-default attribute (OCU-01-002)

### DIFF
--- a/ppd/ppd-generator.c
+++ b/ppd/ppd-generator.c
@@ -419,8 +419,11 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
   cupsFilePrintf(fp, "*ShortNickName: \"%s %s\"\n", make, model);
 
   // Which is the default output bin?
-  if ((attr = ippFindAttribute(supported, "output-bin-default", IPP_TAG_ZERO))
-      != NULL)
+  if ((attr = ippFindAttribute(supported, "output-bin-default",
+			       IPP_TAG_ZERO)) != NULL &&
+      (ippGetValueTag(attr) == IPP_TAG_NAME ||
+       ippGetValueTag(attr) == IPP_TAG_NAMELANG ||
+       ippGetValueTag(attr) == IPP_TAG_KEYWORD))
     defaultoutbin = strdup(ippGetString(attr, 0, NULL));
   // Find out on which position of the list of output bins the default one is,
   // if there is no default bin, take the first of this list

--- a/ppd/ppd-generator.c
+++ b/ppd/ppd-generator.c
@@ -2467,7 +2467,10 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
     //
 
     if ((attr = ippFindAttribute(supported, "print-content-optimize-default",
-				 IPP_TAG_ZERO)) != NULL)
+				 IPP_TAG_ZERO)) != NULL &&
+	(ippGetValueTag(attr) == IPP_TAG_NAME ||
+	 ippGetValueTag(attr) == IPP_TAG_NAMELANG ||
+	 ippGetValueTag(attr) == IPP_TAG_KEYWORD))
       strlcpy(ppdname, ippGetString(attr, 0, NULL), sizeof(ppdname));
     else
       strlcpy(ppdname, "auto", sizeof(ppdname));
@@ -2504,7 +2507,10 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
     //
 
     if ((attr = ippFindAttribute(supported, "print-rendering-intent-default",
-				 IPP_TAG_ZERO)) != NULL)
+				 IPP_TAG_ZERO)) != NULL &&
+	(ippGetValueTag(attr) == IPP_TAG_NAME ||
+	 ippGetValueTag(attr) == IPP_TAG_NAMELANG ||
+	 ippGetValueTag(attr) == IPP_TAG_KEYWORD))
       strlcpy(ppdname, ippGetString(attr, 0, NULL), sizeof(ppdname));
     else
       strlcpy(ppdname, "auto", sizeof(ppdname));
@@ -2544,7 +2550,10 @@ ppdCreatePPDFromIPP2(char         *buffer,          // I - Filename buffer
     //
 
     if ((attr = ippFindAttribute(supported, "print-scaling-default",
-				 IPP_TAG_ZERO)) != NULL)
+				 IPP_TAG_ZERO)) != NULL &&
+	(ippGetValueTag(attr) == IPP_TAG_NAME ||
+	 ippGetValueTag(attr) == IPP_TAG_NAMELANG ||
+	 ippGetValueTag(attr) == IPP_TAG_KEYWORD))
       strlcpy(ppdname, ippGetString(attr, 0, NULL), sizeof(ppdname));
     else
       strlcpy(ppdname, "auto", sizeof(ppdname));


### PR DESCRIPTION
### What this fixes

Fixes #77 (audit finding OCU-01-002).

`ppdCreatePPDFromIPP2()` looks up `output-bin-default` with `IPP_TAG_ZERO`, then passes the result straight into `strdup(ippGetString(...))`. If the attribute has a non-string tag (like an integer), `ippGetString()` returns NULL and `strdup(NULL)` crashes.

### The fix

Check the value tag is a string type (`IPP_TAG_NAME`, `IPP_TAG_NAMELANG`, or `IPP_TAG_KEYWORD`) before calling `strdup(ippGetString(...))`. Wrong-tag values fall through to the existing "no default bin" path.

Normal printers aren't affected — real `output-bin-default` values are keywords or names.