### PR TITLE
ci: make source-@master legs non-blocking, label failure origin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,14 @@ jobs:
   build-matrix:
     name: Build & Test (${{ matrix.arch }}, ${{ matrix.cups }})
     runs-on: ${{ matrix.runs-on }}
+    # The source-* legs build their CUPS / libcupsfilters from OpenPrinting
+    # @master, an unpinned moving target: a transient breakage there (e.g.
+    # libcups master failing its own `make install`) reddens the leg through no
+    # fault of libppd.  Keep the distro system-2x leg required (blocking), but
+    # let the source-@master legs report without blocking the PR.  ci-setup.sh
+    # annotates each failure as UPSTREAM-DEP-FAILED vs LIBPPD-FAILED so a real
+    # libppd regression on these legs is still visible even while non-blocking.
+    continue-on-error: ${{ matrix.cups != 'system-2x' }}
     # Building CUPS / libcupsfilters from source under QEMU is slow; allow plenty.
     timeout-minutes: 360
 

--- a/ci/ci-setup.sh
+++ b/ci/ci-setup.sh
@@ -34,6 +34,28 @@
 # runners; it detects which automatically.
 set -eu
 
+# Classify a failure so CI (and humans) can tell an upstream-dependency
+# breakage apart from a real libppd failure.  Each invocation of this script
+# handles exactly one subcommand, so $1 identifies which side failed:
+# providing the CUPS / libcupsfilters stack (built from @master on the
+# source-* legs, an unpinned moving target) vs building/testing libppd itself.
+# The source-* matrix legs are non-blocking precisely because of the former
+# class of transient upstream breakage; this label makes the distinction
+# explicit on both native and emulated legs (they run the same script).
+_subcmd="${1:-}"
+_classify_failure() {
+	rc=$?
+	[ "$rc" -eq 0 ] && exit 0
+	case "$_subcmd" in
+		cups|pdfio|libcupsfilters)
+			echo "::error::UPSTREAM-DEP-FAILED: '$_subcmd' failed while building the CUPS/libcupsfilters stack (from @master on the source-* legs). This is an upstream-dependency breakage, not a libppd bug." ;;
+		build-libppd)
+			echo "::error::LIBPPD-FAILED: libppd build/test failed." ;;
+	esac
+	exit "$rc"
+}
+trap _classify_failure EXIT
+
 PDFIO_VER=1.6.4
 LIBCUPSFILTERS_URL="${LIBCUPSFILTERS_URL:-https://github.com/OpenPrinting/libcupsfilters.git}"
 LIBCUPSFILTERS_REF="${LIBCUPSFILTERS_REF:-master}"


### PR DESCRIPTION
## What

The build matrix's `source-2.5.x` and `source-3.x` legs build CUPS and libcupsfilters from `OpenPrinting/*@master` — an unpinned moving target. A transient breakage upstream (e.g. libcups master failing its own `make install`) reddens those legs through no fault of libppd. Concrete case: PR #78's `source-3.x` legs went red on 2026-07-15, but the identical commit passed 12/12 when merged to master the next day — same libppd code, only the libcups-master snapshot differed.

This makes the source-`@master` legs non-blocking on PRs while keeping the signal:

- **`build.yml`**: job-level `continue-on-error: ${{ matrix.cups != 'system-2x' }}` — the `source-2.5.x`/`source-3.x` legs no longer fail the run; the distro `system-2x` leg stays required (blocking).
- **`ci/ci-setup.sh`**: an `EXIT`-trap classifier labels each failure as `UPSTREAM-DEP-FAILED` (building the CUPS/libcupsfilters stack) vs `LIBPPD-FAILED` (libppd build/test), so a genuine libppd regression on a non-blocking leg is still visible at a glance. Same script drives native and emulated legs, so both are covered.

## Why

Keeps the multi-CUPS-against-master coverage (catches real upstream breakage early) without letting transient upstream reds block unrelated PRs.

## Validation

Full 12-combo matrix (4 arches × {system-2x, source-2.5.x, source-3.x}) green on the branch.
