### PR TITLE
Add cppcheck static-analysis CI

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,52 @@
+name: cppcheck
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+jobs:
+  cppcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install cppcheck
+        run: |
+          # Retry to ride out transient Ubuntu mirror sync failures (matches build.yml)
+          sudo apt-get update -o Acquire::Retries=3
+          sudo apt-get install -y -o Acquire::Retries=3 cppcheck
+
+      - name: Run cppcheck
+        run: |
+          # The PPD-compiler sources (ppdc*.{h,cxx}) plus encode.c, ppd-cache.c,
+          # raster-interpret.c and ppdc-import.cxx are inherited verbatim from CUPS
+          # (github.com/OpenPrinting/cups); their findings are suppressed here to
+          # keep that code identical to upstream instead of diverging it. The rest
+          # are cppcheck false positives (short-circuited NULL checks and a deflate
+          # output buffer) in libppd's own code.
+          cppcheck \
+            --enable=warning,performance,portability \
+            --error-exitcode=1 \
+            --inline-suppr \
+            --suppress=missingIncludeSystem \
+            --suppress=unknownMacro \
+            --suppress=noCopyConstructor \
+            --suppress=noOperatorEq \
+            --suppress=uninitvar:ppd/encode.c \
+            --suppress=invalidScanfArgType_int:ppd/ppd-cache.c \
+            --suppress=shiftNegativeLHS:ppd/raster-interpret.c \
+            --suppress=invalidscanf:ppd/ppdc-import.cxx \
+            --suppress=arrayIndexThenCheck:ppd/ppdc.cxx \
+            --suppress=identicalInnerCondition:ppd/ppd-collection.cxx \
+            --suppress=nullPointerRedundantCheck:ppd/rastertops.c \
+            --suppress=uninitvar:ppd/rastertops.c \
+            --suppress=nullPointerRedundantCheck:ppd/test_ppd_attr.c \
+            --suppress=nullPointerRedundantCheck:ppd/test_ppd_custom.c \
+            -DVERSION="$(grep -oP 'AC_INIT\(\[[^\]]*\],\s*\[\K[^\]]*' configure.ac)" \
+            .


### PR DESCRIPTION
Adds a cppcheck static-analysis workflow to libppd, matching the rest of the OpenPrinting stack.

libppd carries the PPD-compiler sources (`ppd/ppdc*.{h,cxx}`) plus `encode.c`, `ppd-cache.c`, `raster-interpret.c` and `ppdc-import.cxx` **verbatim from CUPS** (github.com/OpenPrinting/cups). I checked upstream CUPS (master and 2.4.x) and that code is unchanged there, so rather than diverging it, the workflow suppresses those findings via `--suppress` (documented inline). The remaining suppressions are cppcheck false positives in libppd's own code (short-circuited NULL checks and a `deflate` output buffer). No source files are modified.
